### PR TITLE
Fixed incorrect reference to throttled package

### DIFF
--- a/reseed/server.go
+++ b/reseed/server.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/PuerkitoBio/throttled"
-	"github.com/PuerkitoBio/throttled/store"
+	"gopkg.in/throttled/throttled.v2"
+	"gopkg.in/throttled/throttled.v2/store"
 	"github.com/gorilla/handlers"
 	"github.com/justinas/alice"
 )


### PR DESCRIPTION
Throttled package is now found at gopkg.in/throttled/throttled.v2
